### PR TITLE
Replace `isInTheFuture` with `isToday` for date assertions example

### DIFF
--- a/site/docs/adopt-assertj/type-specific-assertions.md
+++ b/site/docs/adopt-assertj/type-specific-assertions.md
@@ -203,7 +203,7 @@ class DateAssertions {
 
         assertThat(today)
                 .hasYear(2025)
-                .isInTheFuture()  // relative to comparison date
+                .isToday()
                 .isBetween(LocalDate.of(2025, 1, 1), LocalDate.of(2025, 12, 31));
     }
 }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?


## What's your motivation?
The test using `isInTheFuture` assertion will always fail

## Anything in particular you'd like reviewers to focus on?
I replaced it with `isToday`, but it could be replaced by another assertions since the idea is to demonstrate type specific assertions (`isNotInTheFuture` maybe)

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
