### PR TITLE
Deduplicate examples across bad-habits and old-habits docs

### DIFF
--- a/site/docs/bad-habits/try-catch.md
+++ b/site/docs/bad-habits/try-catch.md
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 
 Using try/catch blocks with `fail()` calls to test for exceptions is an awkward outdated pattern.
 JUnit4 introduced the `@Test(expected=...)` annotation parameter to simplify this pattern, but it had its own limitations.
-An alternative `@Rule ExpectedException` approach was also available, but it was more verbose and more disconnected.
+An alternative [`@Rule ExpectedException`](../old-habits/junit4.md#expectedexception-rule) approach was also available, but it was more verbose and more disconnected.
 
 <Tabs>
 <TabItem value="before" label="Before">

--- a/site/docs/old-habits/hamcrest.md
+++ b/site/docs/old-habits/hamcrest.md
@@ -14,9 +14,82 @@ The matcher-based approach requires many static imports, has less discoverable A
 
 Hamcrest requires composing matchers with `is()`, `not()`, and `nullValue()` to express simple assertions.
 This leads to verbose, nested calls that are harder to read than fluent assertions.
-For example, a simple null check becomes `assertThat(value, is(not(nullValue())))` instead of AssertJ's `assertThat(value).isNotNull()`.
 
-For a full side-by-side comparison of verbose assertions versus AssertJ, see [JUnit 3 - Limited expressiveness](junit3.md#limited-expressiveness).
+<Tabs>
+<TabItem value="before" label="Before">
+
+```java title="HamcrestTest.java"
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+
+class HamcrestTest {
+
+    @Test
+    void bundle() {
+        List<Book> books = new Bundle().getBooks();
+
+        assertThat(books, is(not(nullValue())));
+        assertThat(books, hasSize(3));
+        assertThat(books, hasItem(new Book("Effective Java", "Joshua Bloch", 2001)));
+        assertThat(books, hasItem(new Book("Java Concurrency in Practice", "Brian Goetz", 2006)));
+        assertThat(books, hasItem(new Book("Clean Code", "Robert C. Martin", 2008)));
+        assertThat(books, not(hasItem(new Book("Java 8 in Action", "Raoul-Gabriel Urma", 2014))));
+    }
+}
+```
+
+:::warning
+
+Hamcrest requires numerous static imports and verbose matcher composition like `is(not(nullValue()))`.
+Each assertion is a separate statement, making the test longer and harder to maintain.
+
+:::
+
+</TabItem>
+<TabItem value="after" label="After">
+
+```java title="HamcrestTest.java"
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HamcrestTest {
+
+    @Test
+    void bundle() {
+        List<Book> books = new Bundle().getBooks();
+
+        assertThat(books)
+                .isNotNull()
+                .hasSize(3)
+                .contains(
+                        new Book("Effective Java", "Joshua Bloch", 2001),
+                        new Book("Java Concurrency in Practice", "Brian Goetz", 2006),
+                        new Book("Clean Code", "Robert C. Martin", 2008))
+                .doesNotContain(new Book("Java 8 in Action", "Raoul-Gabriel Urma", 2014));
+    }
+}
+```
+
+:::tip
+
+AssertJ's fluent API chains multiple assertions together, making tests more concise and readable.
+IDE autocomplete makes it easy to discover available assertions without memorizing static imports.
+
+:::
+
+</TabItem>
+</Tabs>
 
 ## Confusing matcher semantics
 

--- a/site/docs/old-habits/hamcrest.md
+++ b/site/docs/old-habits/hamcrest.md
@@ -14,82 +14,9 @@ The matcher-based approach requires many static imports, has less discoverable A
 
 Hamcrest requires composing matchers with `is()`, `not()`, and `nullValue()` to express simple assertions.
 This leads to verbose, nested calls that are harder to read than fluent assertions.
+For example, a simple null check becomes `assertThat(value, is(not(nullValue())))` instead of AssertJ's `assertThat(value).isNotNull()`.
 
-<Tabs>
-<TabItem value="before" label="Before">
-
-```java title="HamcrestTest.java"
-import org.junit.jupiter.api.Test;
-
-import java.util.List;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.nullValue;
-
-class HamcrestTest {
-
-    @Test
-    void bundle() {
-        List<Book> books = new Bundle().getBooks();
-
-        assertThat(books, is(not(nullValue())));
-        assertThat(books, hasSize(3));
-        assertThat(books, hasItem(new Book("Effective Java", "Joshua Bloch", 2001)));
-        assertThat(books, hasItem(new Book("Java Concurrency in Practice", "Brian Goetz", 2006)));
-        assertThat(books, hasItem(new Book("Clean Code", "Robert C. Martin", 2008)));
-        assertThat(books, not(hasItem(new Book("Java 8 in Action", "Raoul-Gabriel Urma", 2014))));
-    }
-}
-```
-
-:::warning
-
-Hamcrest requires numerous static imports and verbose matcher composition like `is(not(nullValue()))`.
-Each assertion is a separate statement, making the test longer and harder to maintain.
-
-:::
-
-</TabItem>
-<TabItem value="after" label="After">
-
-```java title="HamcrestTest.java"
-import org.junit.jupiter.api.Test;
-
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
-class HamcrestTest {
-
-    @Test
-    void bundle() {
-        List<Book> books = new Bundle().getBooks();
-
-        assertThat(books)
-                .isNotNull()
-                .hasSize(3)
-                .contains(
-                        new Book("Effective Java", "Joshua Bloch", 2001),
-                        new Book("Java Concurrency in Practice", "Brian Goetz", 2006),
-                        new Book("Clean Code", "Robert C. Martin", 2008))
-                .doesNotContain(new Book("Java 8 in Action", "Raoul-Gabriel Urma", 2014));
-    }
-}
-```
-
-:::tip
-
-AssertJ's fluent API chains multiple assertions together, making tests more concise and readable.
-IDE autocomplete makes it easy to discover available assertions without memorizing static imports.
-
-:::
-
-</TabItem>
-</Tabs>
+For a full side-by-side comparison of verbose assertions versus AssertJ, see [JUnit 3 - Limited expressiveness](junit3.md#limited-expressiveness).
 
 ## Confusing matcher semantics
 

--- a/site/docs/old-habits/junit4.md
+++ b/site/docs/old-habits/junit4.md
@@ -21,29 +21,14 @@ This restriction was removed in JUnit 5, where package-private visibility is suf
 ```java title="JUnitFourTest.java"
 import org.junit.Test;
 
-import java.util.List;
-
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 public class JUnitFourTest {
 
     @Test
-    public void bundle() {
-        List<Book> books = new Bundle().getBooks();
-
-        assertNotNull(books);
-        assertEquals(3, books.size());
-        assertTrue(books.contains(new Book("Effective Java", "Joshua Bloch", 2001)));
-        assertTrue(books.contains(new Book("Java Concurrency in Practice", "Brian Goetz", 2006)));
-        assertTrue(books.contains(new Book("Clean Code", "Robert C. Martin", 2008)));
-        assertFalse(books.contains(new Book("Java 8 in Action", "Raoul-Gabriel Urma", 2014)));
-
-        String expectedTitle = books.get(0).getTitle();
-        assertNotNull("Title not null", expectedTitle);
-        assertEquals("Title should match", "Effective Java", expectedTitle);
+    public void greeting() {
+        String greeting = new Greeter().greet("World");
+        assertEquals("Hello, World!", greeting);
     }
 }
 ```
@@ -51,7 +36,6 @@ public class JUnitFourTest {
 :::warning
 
 JUnit 4 requires test classes and methods to be public, adding unnecessary boilerplate.
-The basic assertion library also makes tests verbose and less expressive.
 
 :::
 
@@ -61,27 +45,14 @@ The basic assertion library also makes tests verbose and less expressive.
 ```java title="JUnitFourTest.java"
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 class JUnitFourTest {
 
     @Test
-    void bundle() {
-        List<Book> books = new Bundle().getBooks();
-
-        assertThat(books)
-                .hasSize(3)
-                .contains(
-                        new Book("Effective Java", "Joshua Bloch", 2001),
-                        new Book("Java Concurrency in Practice", "Brian Goetz", 2006),
-                        new Book("Clean Code", "Robert C. Martin", 2008))
-                .doesNotContain(new Book("Java 8 in Action", "Raoul-Gabriel Urma", 2014));
-
-        assertThat(books.get(0).getTitle())
-                .as("Title should match")
-                .isEqualTo("Effective Java");
+    void greeting() {
+        String greeting = new Greeter().greet("World");
+        assertThat(greeting).isEqualTo("Hello, World!");
     }
 }
 ```
@@ -89,79 +60,27 @@ class JUnitFourTest {
 :::tip
 
 JUnit 5 allows package-private test classes and methods, reducing boilerplate.
-Combined with AssertJ, tests become more concise and expressive.
 
 :::
 
 </TabItem>
 </Tabs>
+
+For a full comparison of JUnit assertion expressiveness before and after migrating to AssertJ, see [JUnit 3 - Limited expressiveness](junit3.md#limited-expressiveness).
 
 ## Backwards argument order
 
-JUnit 4 improved on JUnit 3 by standardizing argument order, but it's still backwards compared to JUnit 5.
-In JUnit 4, the expected value comes first, while in JUnit 5 the actual value comes first to match natural reading order.
+JUnit 4's argument order conventions are inconsistent and error-prone.
+For example, `assertNotNull` takes the value first and message second, while `assertEquals` takes message first, then expected, then actual.
+This inconsistency carries over when upgrading to JUnit 5 without fixing argument order.
 
-<Tabs>
-<TabItem value="before" label="Before">
-
-```java title="JUnitFourTest.java"
-import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
-public class JUnitFourTest {
-
-    @Test
-    public void incorrectArgumentOrder() {
-        String actualTitle = new Bundle().getBooks().get(0).getTitle();
-        assertNotNull(actualTitle, "Title not null");
-        assertEquals("Title should match", actualTitle, "Effective Java");
-    }
-}
-```
-
-:::danger
-
-In JUnit 4, `assertNotNull` takes the value first and message second, while `assertEquals` takes message first, then expected, then actual.
-This inconsistency leads to errors. The test above will incorrectly pass because it's comparing the actual title to the message string.
-
-:::
-
-</TabItem>
-<TabItem value="after" label="After">
-
-```java title="JUnitFourTest.java"
-import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
-class JUnitFourTest {
-
-    @Test
-    void incorrectArgumentOrder() {
-        String actualTitle = new Bundle().getBooks().get(0).getTitle();
-        assertThat(actualTitle)
-                .as("Title should match")
-                .isNotNull()
-                .isEqualTo("Effective Java");
-    }
-}
-```
-
-:::tip
-
-AssertJ eliminates argument order confusion with its fluent API that always starts with the actual value.
-
-:::
-
-</TabItem>
-</Tabs>
+For detailed examples of how backwards argument order leads to confusing failures and silently passing tests, see [Backwards](../bad-habits/backwards.md).
 
 ## ExpectedException rule
 
 JUnit 4 introduced the `@Rule ExpectedException` to test for exceptions, which was an improvement over try/catch blocks.
 However, it's disconnected from the code that throws the exception and can lead to confusing test logic.
+For the even older try/catch with `fail()` pattern, see [Try/Catch fail](../bad-habits/try-catch.md).
 
 <Tabs>
 <TabItem value="before" label="Before">


### PR DESCRIPTION
## Summary

- Replaced the repeated Book/Bundle list assertion example in `junit4.md` with a minimal example focused on public visibility (its unique point), linking to `junit3.md` for the full comparison
- Replaced the repeated Book/Bundle example in `hamcrest.md`'s "Verbose matcher composition" section with a concise explanation and link to `junit3.md`
- Replaced the backwards argument order section in `junit4.md` with a short paragraph linking to `backwards.md`, which has richer examples
- Added cross-references between the exception testing pages (`try-catch.md` and `junit4.md`)

## Test plan

- [x] Docusaurus build passes with no broken anchors or warnings