### PR TITLE
Group openrewrite dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      openrewrite:
+        patterns:
+          - "org.openrewrite*:*"
   - package-ecosystem: "npm"
     directory: "/site"
     schedule:


### PR DESCRIPTION
## Summary
- Group all `org.openrewrite*` Maven dependency updates into a single Dependabot PR

## Test plan
- [ ] CI checks pass