### PR TITLE
Group react and react-dom dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,7 @@ updates:
       docusaurus:
         patterns:
           - "@docusaurus/*"
+      react:
+        patterns:
+          - "react"
+          - "react-dom"


### PR DESCRIPTION
- PR #117 failed CI because Dependabot bumped `react` without `react-dom`, and Docusaurus requires the two to be on the exact same version.

Adding a `react` group to the npm ecosystem in `.github/dependabot.yml` so `react` and `react-dom` are always bumped together in a single PR, preventing future version-mismatch build failures.