### PR TITLE
Resolve org.openrewrite dependencies from Code Genome Project

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -18,6 +18,10 @@ jobs:
     name: Build and verify
     runs-on: ubuntu-latest
 
+    env:
+      CODEGENOME_USERNAME: ${{ secrets.CODEGENOME_USERNAME }}
+      CODEGENOME_TOKEN: ${{ secrets.CODEGENOME_TOKEN }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -28,6 +32,9 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
           cache: 'maven'
+          server-id: codegenome
+          server-username: CODEGENOME_USERNAME
+          server-password: CODEGENOME_TOKEN
 
       - name: Build with Maven
         run: mvn verify

--- a/books/pom.xml
+++ b/books/pom.xml
@@ -55,6 +55,27 @@
         </dependency>
     </dependencies>
 
+    <repositories>
+        <repository>
+            <id>codegenome</id>
+            <name>Code Genome Project</name>
+            <url>https://artifacts.codegenomeproject.org/maven</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>codegenome</id>
+            <name>Code Genome Project</name>
+            <url>https://artifacts.codegenomeproject.org/maven</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
+
     <build>
         <plugins>
             <plugin>

--- a/orders/pom.xml
+++ b/orders/pom.xml
@@ -52,6 +52,27 @@
         </dependency>
     </dependencies>
 
+    <repositories>
+        <repository>
+            <id>codegenome</id>
+            <name>Code Genome Project</name>
+            <url>https://artifacts.codegenomeproject.org/maven</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>codegenome</id>
+            <name>Code Genome Project</name>
+            <url>https://artifacts.codegenomeproject.org/maven</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
+
     <build>
         <plugins>
             <!-- Generate AssertJ assertion classes for domain objects with `mvn compile assertj:generate-assertions` -->

--- a/pom.xml
+++ b/pom.xml
@@ -14,4 +14,27 @@
         <module>orders</module>
         <module>recipes</module>
     </modules>
+
+    <!-- Serves org.openrewrite and io.moderne releases and snapshots ahead of Maven Central;
+         credentials come from the `codegenome` server id in your settings.xml. -->
+    <repositories>
+        <repository>
+            <id>codegenome</id>
+            <name>Code Genome Project</name>
+            <url>https://artifacts.codegenomeproject.org/maven</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>codegenome</id>
+            <name>Code Genome Project</name>
+            <url>https://artifacts.codegenomeproject.org/maven</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
 </project>

--- a/recipes/pom.xml
+++ b/recipes/pom.xml
@@ -103,6 +103,27 @@
         </dependency>
     </dependencies>
 
+    <repositories>
+        <repository>
+            <id>codegenome</id>
+            <name>Code Genome Project</name>
+            <url>https://artifacts.codegenomeproject.org/maven</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>codegenome</id>
+            <name>Code Genome Project</name>
+            <url>https://artifacts.codegenomeproject.org/maven</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
+
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
Adds the `codegenome` repository and pluginRepository (`https://artifacts.codegenomeproject.org/maven`, snapshots enabled) so `org.openrewrite` and `io.moderne` artifacts resolve from the Code Genome Project ahead of Maven Central. It is declared in all four poms rather than just the aggregator because Maven inherits repositories only through `<parent>`, and every module here parents to `spring-boot-starter-parent`.

The Maven workflow now feeds `CODEGENOME_USERNAME` / `CODEGENOME_TOKEN` into the settings.xml that `setup-java` generates; those repository secrets still need to be created, and until they exist CI simply resolves from Central as before. Verified both paths against a clean local repository: with credentials 53 `org/openrewrite` artifacts came from codegenome, and without them the build still succeeds by falling back to Central rather than failing on 401 — so fork and Dependabot PRs are unaffected.